### PR TITLE
fix(frontend): failed to build project from frontend plugin

### DIFF
--- a/tab/js/default/package.json
+++ b/tab/js/default/package.json
@@ -6,6 +6,7 @@
     "@microsoft/teams-js": "^1.6.0",
     "teamsdev-client": "^1.1.0",
     "@fluentui/react-northstar": "^0.51.0",
+    "tslib": "^2.0.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.1.2",

--- a/tab/js/with-function/package.json
+++ b/tab/js/with-function/package.json
@@ -7,6 +7,7 @@
     "teamsdev-client": "^1.1.0",
     "@fluentui/react-northstar": "^0.51.0",
     "axios": "^0.21.1",
+    "tslib": "^2.0.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.1.2",


### PR DESCRIPTION
Add tslib@2.0.0 dependency to workaround the build error in frontend plugin. 
Bug 9712280.