### PR TITLE
refactor: optimize dedup logic

### DIFF
--- a/bot/js/bots/teamsBot.js
+++ b/bot/js/bots/teamsBot.js
@@ -14,7 +14,6 @@ class TeamsBot extends DialogBot {
      */
     constructor(conversationState, userState, dialog) {
         super(conversationState, userState, dialog);
-        this.conversationState= conversationState;
         this.onMembersAdded(async (context, next) => {
             const membersAdded = context.activity.membersAdded;
             for (let cnt = 0; cnt < membersAdded.length; cnt++) {
@@ -48,32 +47,11 @@ class TeamsBot extends DialogBot {
             context.activity &&
             context.activity.name === tokenExchangeOperationName
         ) {
-            if (await this.shouldDedup(context)) {
+            if (await this.dialog.shouldDedup(context)) {
                 return;
             }
         }
         await this.dialog.run(context, this.dialogState);
-    }
-
-    // If a user is signed into multiple Teams clients, the Bot might receive a "signin/tokenExchange" from each client.
-    // Each token exchange request for a specific user login will have an identical activity.value.Id.
-    // Only one of these token exchange requests should be processed by the bot.  For a distributed bot in production,
-    // this requires a distributed storage to ensure only one token exchange is processed.
-    async shouldDedup(context) {
-        const storeItem = { [context.activity.value.id]: "" };
-
-        const state = this.conversationState.createProperty(
-            context.activity.value.id
-        );
-
-        const value = await state.get(context);
-        if (value) {
-            return true;
-        }
-        await state.set(context, storeItem);
-        await this.conversationState.saveChanges(context, false);
-
-        return false;
     }
 }
 

--- a/bot/js/dialogs/mainDialog.js
+++ b/bot/js/dialogs/mainDialog.js
@@ -17,7 +17,6 @@ const {
     OnBehalfOfUserCredential,
     TeamsBotSsoPrompt
 } = require("teamsdev-client");
-const { MemoryStorage } = require('botbuilder-core');
 
 class MainDialog extends LogoutDialog {
     constructor(dedupStorage) {
@@ -114,8 +113,10 @@ class MainDialog extends LogoutDialog {
     }
 
     async onEndDialog(context, instance, reason) {
-        await this.dedupStorage.delete(this.dedupStorageKeys);
-        this.dedupStorageKeys = [];
+        const conversationId = context.activity.conversation.id;
+        const currentDedupKeys = this.dedupStorageKeys.filter(key=>key.indexOf(conversationId) > 0);
+        await this.dedupStorage.delete(currentDedupKeys);
+        this.dedupStorageKeys = this.dedupStorageKeys.filter(key=>key.indexOf(conversationId) < 0);
     }
 
     // If a user is signed into multiple Teams clients, the Bot might receive a "signin/tokenExchange" from each client.

--- a/bot/js/index.js
+++ b/bot/js/index.js
@@ -48,12 +48,16 @@ adapter.onTurnError = async (context, error) => {
 // A bot requires a state storage system to persist the dialog and user state between messages.
 const memoryStorage = new MemoryStorage();
 
+// For a distributed bot in production,
+// this requires a distributed storage to ensure only one token exchange is processed.
+const dedupMemory = new MemoryStorage();
+
 // Create conversation and user state with in-memory storage provider.
 const conversationState = new ConversationState(memoryStorage);
 const userState = new UserState(memoryStorage);
 
 // Create the main dialog.
-const dialog = new MainDialog();
+const dialog = new MainDialog(dedupMemory);
 // Create the bot that will handle incoming messages.
 const bot = new TeamsBot(conversationState, userState, dialog);
 

--- a/bot/js/index.js
+++ b/bot/js/index.js
@@ -55,7 +55,7 @@ const userState = new UserState(memoryStorage);
 // Create the main dialog.
 const dialog = new MainDialog();
 // Create the bot that will handle incoming messages.
-const bot = new TeamsBot(conversationState, userState, dialog, memoryStorage);
+const bot = new TeamsBot(conversationState, userState, dialog);
 
 // Create HTTP server.
 const server = restify.createServer();


### PR DESCRIPTION
Conversation state would be auto removed when dialog end, so we do not need to manage this cache manually.
Compare with using memory cache, it also can be easily integration with other cache types

![image](https://user-images.githubusercontent.com/5545529/115198349-878d2180-a124-11eb-8969-034687134d8a.png)
