### PR TITLE
fix(bot): gracefully shutdown bot server

### DIFF
--- a/bot/js/index.js
+++ b/bot/js/index.js
@@ -80,3 +80,10 @@ server.get(
         directory: path.join(__dirname, 'public')
     })
 );
+
+// Gracefully shutdown HTTP server
+['exit', 'uncaughtException', 'SIGINT', 'SIGTERM', 'SIGUSR1', 'SIGUSR2' ].forEach((event) => {
+    process.on(event, () => {
+        server.close();
+    });
+});

--- a/bot/ts/index.ts
+++ b/bot/ts/index.ts
@@ -88,3 +88,10 @@ server.get(
         directory: path.join(__dirname, "public")
     })
 );
+
+// Gracefully shutdown HTTP server
+['exit', 'uncaughtException', 'SIGINT', 'SIGTERM', 'SIGUSR1', 'SIGUSR2' ].forEach((event) => {
+    process.on(event, () => {
+        server.close();
+    });
+});


### PR DESCRIPTION
Close the HTTP server when process exits. This helps fix some cases of "pty" and "port in use" issues since it releases the used port and let Node process to be terminated.

@kuojianlu @IvanJobs @YitongFeng-git  -  (I cannot add reviewer by myself) Please help review, thanks!